### PR TITLE
Add USWDS skeleton site

### DIFF
--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -1,0 +1,3 @@
+_site
+.sass-cache
+.jekyll-metadata

--- a/sandbox/Gemfile
+++ b/sandbox/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "jekyll"
+gem "uswds-jekyll"
+
+group :jekyll_plugins do
+  gem "jekyll_pages_api_search"
+end

--- a/sandbox/Gemfile.lock
+++ b/sandbox/Gemfile.lock
@@ -1,0 +1,64 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    htmlentities (4.3.4)
+    jekyll (3.6.2)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 3)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.1)
+      sass (~> 3.4)
+    jekyll-watch (1.5.1)
+      listen (~> 3.0)
+    jekyll_pages_api (0.1.6)
+      htmlentities (~> 4.3)
+      jekyll (>= 2.0, < 4.0)
+    jekyll_pages_api_search (0.4.4)
+      jekyll_pages_api (~> 0.1.4)
+      sass (~> 3.4)
+    kramdown (1.16.2)
+    liquid (4.0.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    mercenary (0.3.6)
+    pathutil (0.16.1)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.1)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (2.2.1)
+    ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
+    sass (3.5.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    uswds-jekyll (2.1.0)
+      jekyll (~> 3.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll_pages_api_search
+  uswds-jekyll
+
+BUNDLED WITH
+   1.16.0

--- a/sandbox/_config.yml
+++ b/sandbox/_config.yml
@@ -1,0 +1,8 @@
+title: Thrift Savings Plan
+description:
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+markdown: kramdown
+theme: uswds-jekyll

--- a/sandbox/_data/favicons.yml
+++ b/sandbox/_data/favicons.yml
@@ -1,0 +1,21 @@
+- rel: shortcut icon
+  type: image/ico
+  href: /assets/uswds/img/favicons/favicon.ico
+- rel: icon
+  type: image/png
+  href: /assets/uswds/img/favicons/favicon.png
+- rel: icon
+  type: image/png
+  sizes: 192x192
+  href: /assets/uswds/img/favicons/favicon-192.png
+- rel: apple-touch-icon-precomposed
+  href: /assets/uswds/img/favicons/favicon-57.png
+- rel: apple-touch-icon-precomposed
+  sizes: 72x72
+  href: /assets/uswds/img/favicons/favicon-72.png
+- rel: apple-touch-icon-precomposed
+  sizes: 114x114
+  href: /assets/uswds/img/favicons/favicon-114.png
+- rel: apple-touch-icon-precomposed
+  sizes: 144x144
+  href: /assets/uswds/img/favicons/favicon-144.png

--- a/sandbox/_data/footer.yml
+++ b/sandbox/_data/footer.yml
@@ -1,0 +1,37 @@
+# Whether to show the "Return to top" link; can also be
+# configured as an object with 'text' and 'href' properties.
+top: true
+
+# Which links to show at the top of the footer.
+# This can key into _data/navigation.yml or a list of link objects
+# with 'text' and 'href' properties.
+links: footer
+
+# The optional heading for the footer.
+heading: Thrift Savings Plan
+
+# An array of agency logos to show, side by side, in the lower left
+# of the footer on large screens.
+# If the logo is external add external: true
+logos:
+  - src: /assets/uswds/img/logo-img.png
+    alt: Logo image
+
+contact:
+  links:
+    - type: facebook
+      href: https://tsp.gov/
+      external: true
+    - type: twitter
+      href: https://tsp.gov/
+      external: true
+    - type: youtube
+      href: https://tsp.gov/
+      external: true
+    - type: rss
+      href: https://tsp.gov/
+      external: true
+
+  heading: Agency Contact Center
+  address: |
+    (800) CALL-GOVT

--- a/sandbox/_data/header.yml
+++ b/sandbox/_data/header.yml
@@ -1,0 +1,26 @@
+# This is the configuration for the site header.
+
+# Uncomment this statement (by removing the leading '# ') to set the
+# header title differently from the site's title (as defined in
+# _config.yml).
+
+# title: Header title
+
+# this defines the type of header
+# header types can be 'basic' or 'extended'
+type: extended
+
+primary:
+  # this is a key into _data/navigation.yml
+  links: primary
+
+secondary:
+  # this is a key into _data/navigation.yml
+  links: secondary
+
+  # to enable search, change this to an object with 'action' and
+  # 'query' keys, e.g.
+  #
+  search:
+    action: /search/
+    query: q

--- a/sandbox/_data/navigation.yml
+++ b/sandbox/_data/navigation.yml
@@ -1,0 +1,60 @@
+# This file defines the structure of various named navigational
+# listings, any of which can be used (with some caveats) as the
+# links in your header, footer, and per-page side navigation.
+#
+# For instance, if you have a "primary" navigation list here, you
+# can use that as your header's primary navigation by setting
+# `primary.links` to "primary":
+#
+# primary:
+#   links: primary
+#
+primary:
+  - text: Documentation
+    href: /about/
+  - text: Navigation section
+    links:
+      - text: Demo link A
+        href: /about/
+      - text: Demo link B
+        href: /about/
+      - text: Demo link C
+        href: /about/
+  - text: Referenced section
+    links: footer
+  - text: External link
+    href: https://tsp.gov
+    external: true
+
+secondary:
+  - text: Documentation
+    href: /about/
+  - text: External link
+    href: https://18f.gsa.gov
+    external: true
+
+docs:
+  - text: Documentation
+    href: /about/
+  - text: Navigation section
+    links:
+      - text: Demo link A
+        href: /about/
+      - text: Demo link B
+        href: /about/
+      - text: Demo link C
+        href: /about/
+  - text: Referenced section
+    links: footer
+  - text: External link
+    href: https://tsp.gov
+    external: true
+
+footer:
+  - text: Documentation
+    href: /about/
+  - text: Demo link
+    href: /about/
+  - text: External link
+    href: https://tsp.gov
+    external: true

--- a/sandbox/about.md
+++ b/sandbox/about.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+
+You can find the source code for Minima at GitHub:
+[jekyll][jekyll-organization] /
+[minima](https://github.com/jekyll/minima)
+
+You can find the source code for Jekyll at GitHub:
+[jekyll][jekyll-organization] /
+[jekyll](https://github.com/jekyll/jekyll)
+
+
+[jekyll-organization]: https://github.com/jekyll

--- a/sandbox/index.md
+++ b/sandbox/index.md
@@ -1,0 +1,50 @@
+---
+title: Home
+permalink: /
+layout: home
+
+hero:
+  image: /assets/uswds/img/hero.png
+  callout:
+    alt: "Hero callout:"
+    text: Call attention to a current priority
+  button:
+    href: /about/
+    text: Learn about what we do
+#  link:
+#    text: Link to more about that priority
+#    href: /link/
+  content: Support the callout with some short explanatory text. You don't need more than a couple of sentences.
+
+tagline: A tagline highlights your approach.
+intro: |
+  The tagline should inspire confidence and interest, focusing on the value that your overall approach offers to your audience. Use a heading typeface and keep your tagline to just a few words, and don’t confuse or mystify.
+
+  Use the right side of the grid to explain the tagline a bit more. What are your goals? How do you do your work? Write in the present tense, and stay brief here. People who are interested can find details on internal pages.
+
+graphics:
+  - image:
+      src: /assets/uswds/img/circle-124.png
+      alt: ''
+    title: Graphic headings can vary.
+    description: Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.
+  - image:
+      src: /assets/uswds/img/circle-124.png
+      alt: ''
+    title: Stick to 6 or fewer words.
+    description: Keep body text to about 30. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.
+  - image:
+      src: /assets/uswds/img/circle-124.png
+      alt: ''
+    title: Never highlight anything without a goal.
+    description: For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.
+  - image:
+      src: /assets/uswds/img/circle-124.png
+      alt: ''
+    title: Could also have 2 or 6.
+    description: In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.
+---
+
+<h2>Section heading</h2>
+<p class="usa-font-lead">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
+<a class="usa-button usa-button-big" href="#">Call to action</a>


### PR DESCRIPTION
This adds a simple Jekyll site with the USWDS theme. This can be used and branched off of for future training sessions and/or prototypes.

![screen shot 2017-12-20 at 10 33 42 am](https://user-images.githubusercontent.com/1178494/34214722-505fd8b4-e571-11e7-834c-2b5ac9ab1900.png)
